### PR TITLE
SM4 cbc 下无法加密超16字节字符BUG

### DIFF
--- a/CSharp/GmSm/Lib/SM4.cs
+++ b/CSharp/GmSm/Lib/SM4.cs
@@ -267,7 +267,7 @@ namespace GmSm.Lib
                     byte[] outBytes = new byte[16];
                     byte[] out1 = new byte[16];
 
-                    Array.Copy(bins, i * 16, inBytes, 0, length > 16 ? 16 : length);
+                    Array.Copy(bins, j * 16 == 0 ? 0 : j * 16 - 1, inBytes, 0, length > 16 ? 16 : length);
                     for (i = 0; i < 16; i++)
                     {
                         outBytes[i] = ((byte)(inBytes[i] ^ iv[i]));


### PR DESCRIPTION
数组复制问题

现在的问题是，是不是所有的Array.Copy在第二次for循环时存在复制数组起始索引都多算一位？